### PR TITLE
ExploreProjectsPage Grid bug - Small devices

### DIFF
--- a/ProjectBank/Client/Pages/Index.razor
+++ b/ProjectBank/Client/Pages/Index.razor
@@ -7,7 +7,7 @@
     <div class="row justify-content-around">
         @foreach (var project in yourProjects)
         {
-            <div class="card col col-xs-12 col-sm-6 col-md-4 col-lg-3" style="width: 18rem;">
+            <div class="card col col-12 col-sm-6 col-md-4 col-lg-3" style="width: 18rem;">
                 <div class="card-body">
                     <h5 class="card-title">@project.Title</h5>
                     <p class="card-text">@project.Description</p>
@@ -21,7 +21,7 @@
 <div class="row justify-content-around">
     @foreach (var project in projectsList)
     {
-        <div class="card mt-4 col col-xs-12 col-sm-6 col-md-4 col-lg-3" style="width: 18rem;">
+        <div class="card mt-4 col col-12 col-sm-6 col-md-4 col-lg-3" style="width: 18rem;">
             <div class="card-body">
                 <h5 class="card-title">@project.Title</h5>
                 <p class="card-text">@project.Description</p>


### PR DESCRIPTION
### Notable changes

Addresses the error described in #227 where small devices would get four cards per row. See attached screenshots.
See [Bootstrap grid documentation](https://getbootstrap.com/docs/5.1/layout/grid/) for documentation on layout sizes.

### Checklist

- [x] I've run the tests and verified that nothing explodes
- [ ] I've added a screenshot of the test report
- [x] The code is formatted with a C# formatter
- [x] I reviewed this pr myself

### Screenshots

<img width="501" alt="Skærmbillede 2021-11-26 kl  15 08 45" src="https://user-images.githubusercontent.com/15281390/143593305-42f897d9-1a6a-4640-bb14-91ecc15cda33.png">

_Before fix_

<img width="498" alt="Skærmbillede 2021-11-26 kl  15 09 17" src="https://user-images.githubusercontent.com/15281390/143593322-493df976-58df-4c71-8b66-27cea5eaa42b.png">

_After Fix_

### Test report screenshot

N/A
