### PR TITLE
Fixed issue where ProjectPage called a non-existing API

### DIFF
--- a/ProjectBank/Client/Pages/ProjectPage.razor
+++ b/ProjectBank/Client/Pages/ProjectPage.razor
@@ -97,7 +97,7 @@
 
     async Task<bool> UserIsParticipant()
     {
-        ProjectDTO[] yourProjects = await Http.GetFromJsonAsync<ProjectDTO[]>("api/apply");
+        ProjectDTO[] yourProjects = await Http.GetFromJsonAsync<ProjectDTO[]>("api/Student");
         if(yourProjects.FirstOrDefault(p => p.Id == Id) != null){
             ApplyText = "Applied";
             Applied = true;


### PR DESCRIPTION
### Notable changes

Fixed issue where ProjectPage called a non-existing API because of renaming ("Apply" -> "Student").

### Checklist

- [x] I've run the tests and verified that nothing explodes
- [x] I've added a screenshot of the test report
- [x] The code is formatted with a C# formatter
- [x] I reviewed this pr myself

### Screenshots

N/A

### Test report screenshot
<img width="1258" alt="Skærmbillede 2021-12-21 kl  09 18 26" src="https://user-images.githubusercontent.com/15281390/146895411-598686f4-edf8-462d-9f90-8c48ee54a8bb.png">


